### PR TITLE
Remove old versions of dynamix.plg

### DIFF
--- a/unRAIDServer.plg
+++ b/unRAIDServer.plg
@@ -332,6 +332,8 @@ else
   echo "Cannot remove, no previous version"
   exit 1
 fi
+echo "Removing old versions of dynamix"
+rm -rf /boot/config/plugins/dynamix.plg
 echo "syncing..."
 sync
 echo "Remove successful - PLEASE REBOOT YOUR SERVER"


### PR DESCRIPTION
Very old versions did not check for OS compatibility and their presence prevents 6.4 from booting correctly